### PR TITLE
Port to fluidsynth 2.0 API

### DIFF
--- a/src/qsynthChannelsForm.cpp
+++ b/src/qsynthChannelsForm.cpp
@@ -248,20 +248,22 @@ void qsynthChannelsForm::updateChannel ( int iChan )
 #else
 	fluid_preset_t *pPreset = ::fluid_synth_get_channel_preset(m_pSynth, iChan);
 	if (pPreset) {
-		int iBank = pPreset->get_banknum(pPreset);
+		int iBank = ::fluid_preset_get_banknum(pPreset);
+		fluid_sfont_t* sfont = ::fluid_preset_get_sfont(pPreset);
+		int sfid = ::fluid_sfont_get_id(sfont);
 	#ifdef CONFIG_FLUID_BANK_OFFSET
-		iBank += ::fluid_synth_get_bank_offset(m_pSynth, (pPreset->sfont)->id);
+		iBank += ::fluid_synth_get_bank_offset(m_pSynth, sfid);
 	#endif
 		pItem->setText(QSYNTH_CHANNELS_BANK,
 			QString::number(iBank));
 		pItem->setText(QSYNTH_CHANNELS_PROG,
-			QString::number(pPreset->get_num(pPreset)));
+			QString::number(::fluid_preset_get_num(pPreset)));
 		pItem->setText(QSYNTH_CHANNELS_NAME,
-			pPreset->get_name(pPreset));
+			::fluid_preset_get_name(pPreset));
 		pItem->setText(QSYNTH_CHANNELS_SFID,
-			QString::number((pPreset->sfont)->id));
+			QString::number(sfid));
 		pItem->setText(QSYNTH_CHANNELS_SFNAME,
-			QFileInfo((pPreset->sfont)->get_name(pPreset->sfont)).baseName());
+			QFileInfo(::fluid_sfont_get_name(sfont)).baseName());
 		// Make this a dirty-operation.
 		m_iDirtyCount++;
 	}

--- a/src/qsynthMainForm.cpp
+++ b/src/qsynthMainForm.cpp
@@ -123,13 +123,6 @@ static qsynthEngine *g_pCurrentEngine = NULL;
 // Hold last shell/server port in use.
 static int g_iLastShellPort = 0;
 
-
-// Needed for server mode.
-static fluid_cmd_handler_t* qsynth_newclient ( void* data, char* )
-{
-	return ::new_fluid_cmd_handler((fluid_synth_t*) data);
-}
-
 #endif
 
 
@@ -1884,8 +1877,8 @@ bool qsynthMainForm::startEngine ( qsynthEngine *pEngine )
 			::fluid_settings_getint(
 				pSetup->fluid_settings(), szShellPort, &g_iLastShellPort);
 			if (g_iLastShellPort == 0) {
-				g_iLastShellPort = ::fluid_settings_getint_default(
-					pSetup->fluid_settings(), szShellPort);
+				::fluid_settings_getint_default(
+					pSetup->fluid_settings(), szShellPort, &g_iLastShellPort);
 			}
 		}
 		// Set the (new) server port for this engne...
@@ -1893,7 +1886,7 @@ bool qsynthMainForm::startEngine ( qsynthEngine *pEngine )
 			pSetup->fluid_settings(), szShellPort, g_iLastShellPort);
 		// Create the server now...
 		pEngine->pServer = ::new_fluid_server(
-			pSetup->fluid_settings(), qsynth_newclient, pEngine->pSynth);
+			pSetup->fluid_settings(), pEngine->pSynth, pEngine->pMidiRouter);
 		if (pEngine->pServer == NULL)
 			appendMessagesError(sPrefix +
 				tr("Failed to create the server.\n\n"
@@ -2017,8 +2010,8 @@ void qsynthMainForm::stopEngine ( qsynthEngine *pEngine )
 		fluid_sfont_t *pSoundFont
 			= ::fluid_synth_get_sfont(pEngine->pSynth, i);
 		if (pSoundFont) {
-			const int iSFID = pSoundFont->id;
-			const QString sName = pSoundFont->get_name(pSoundFont);
+			const int iSFID = ::fluid_sfont_get_id(pSoundFont);
+			const QString sName = ::fluid_sfont_get_name(pSoundFont);
 			appendMessagesColor(sPrefix +
 				tr("Unloading soundfont: \"%1\" (SFID=%2)")
 				.arg(sName).arg(iSFID) + sElipsis, "#999933");
@@ -2538,8 +2531,8 @@ void qsynthMainForm::refreshChorus (void)
 
 	const int    iChorusNr    = ::fluid_synth_get_chorus_nr(pEngine->pSynth);
 	const double fChorusLevel = ::fluid_synth_get_chorus_level(pEngine->pSynth);
-	const double fChorusSpeed = ::fluid_synth_get_chorus_speed_Hz(pEngine->pSynth);
-	const double fChorusDepth = ::fluid_synth_get_chorus_depth_ms(pEngine->pSynth);
+	const double fChorusSpeed = ::fluid_synth_get_chorus_speed(pEngine->pSynth);
+	const double fChorusDepth = ::fluid_synth_get_chorus_depth(pEngine->pSynth);
 	const int    iChorusType  = ::fluid_synth_get_chorus_type(pEngine->pSynth);
 
 	m_ui.ChorusNrDial->setValue(iChorusNr);

--- a/src/qsynthOptions.cpp
+++ b/src/qsynthOptions.cpp
@@ -761,15 +761,15 @@ bool qsynthOptions::savePreset ( qsynthEngine *pEngine, const QString& sPreset )
 	#else
 		fluid_preset_t *pPreset = ::fluid_synth_get_channel_preset(pEngine->pSynth, iChan);
 		if (pPreset) {
-			int iBank = pPreset->get_banknum(pPreset);
+			int iBank = ::fluid_preset_get_banknum(pPreset);
 		#ifdef CONFIG_FLUID_BANK_OFFSET
-			iBank += ::fluid_synth_get_bank_offset(pEngine->pSynth, (pPreset->sfont)->id);
+			iBank += ::fluid_synth_get_bank_offset(pEngine->pSynth, ::fluid_sfont_get_id(::fluid_preset_get_sfont(pPreset)));
 		#endif
 			QString sEntry = QString::number(iChan);
 			sEntry += ':';
 			sEntry += QString::number(iBank);
 			sEntry += ':';
-			sEntry += QString::number(pPreset->get_num(pPreset));
+			sEntry += QString::number(::fluid_preset_get_num(pPreset));
 			m_settings.setValue(sPrefix.arg(iChan + 1), sEntry);
 		}
 	#endif


### PR DESCRIPTION
This is a place-holder PR for porting qsynth to the API of fluidsynth 2.0. Do not merge until 2.0 has been released.

I did not really care of keeping any backward compatibility to 1.1.x. However I also did not remove any code. Depending on the level of compatibility you want, you could remove all code in `CONFIG_FLUID_CHANNEL_INFO`, `CONFIG_FLUID_MIDI_ROUTER` and `!CONFIG_FLUID_SETTINGS_DUPSTR`

One issue remains which is those `FLUID_REVERB_DEFAULT_*` macros in `qsynthOptions.cpp`. With fluidsynth 2.0, [reverb and chorus are actually available as settings](http://www.fluidsynth.org/api-unstable/fluidsettings.xml#synth.chorus.depth). It would be nice if you find a way to do this by using the settings API, specifically `fluid_settings_get???_default()` to read the default values of reverb and chorus settings.