### PR TITLE
Fix for ticket #38. New Setup/Audio/WASAPI Exclusive Mode option added

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ ChangeLog
 
 GIT HEAD
 
+- New Setup/Audio/WASAPI Exclusive Mode option added.
+
 - Fix for Windows runtime error (assertion failed) when compiled
   with MSVC (by Pedro Lopez-Cabanillas GH #39, #40). (EXPERIMENTAL)
 

--- a/src/qsynthOptions.cpp
+++ b/src/qsynthOptions.cpp
@@ -539,6 +539,7 @@ void qsynthOptions::loadSetup ( qsynthSetup *pSetup, const QString& sName )
 	pSetup->sJackName        = m_settings.value("/JackName", "qsynth").toString();
 	pSetup->bJackAutoConnect = m_settings.value("/JackAutoConnect", true).toBool();
 	pSetup->bJackMulti       = m_settings.value("/JackMulti", false).toBool();
+    pSetup->bWasapiExclusive = m_settings.value("/WasapiExclusive", false).toBool();
 #if defined(__OpenBSD__)
 	pSetup->sMidiDevice      = m_settings.value("/MidiDevice", "midithru/0").toString();
 #else
@@ -663,6 +664,7 @@ void qsynthOptions::saveSetup ( qsynthSetup *pSetup, const QString& sName )
 	m_settings.setValue("/JackName",         pSetup->sJackName);
 	m_settings.setValue("/JackAutoConnect",  pSetup->bJackAutoConnect);
 	m_settings.setValue("/JackMulti",        pSetup->bJackMulti);
+    m_settings.setValue("/WasapiExclusive",  pSetup->bWasapiExclusive);
 	m_settings.setValue("/AudioChannels",    pSetup->iAudioChannels);
 	m_settings.setValue("/AudioGroups",      pSetup->iAudioGroups);
 	m_settings.setValue("/AudioBufSize",     pSetup->iAudioBufSize);

--- a/src/qsynthSetup.cpp
+++ b/src/qsynthSetup.cpp
@@ -143,6 +143,10 @@ void qsynthSetup::realize (void)
 	::fluid_settings_setint(m_pFluidSettings, pszKey, int(bJackMulti));
 #endif
 
+    pszKey = (char *) "audio.wasapi.exclusive-mode";
+    ::fluid_settings_setint(m_pFluidSettings, pszKey,
+        int(bWasapiExclusive));
+
 	if (!sSampleFormat.isEmpty()) {
 		pszKey = (char *) "audio.sample-format";
 		::fluid_settings_setstr(m_pFluidSettings, pszKey,

--- a/src/qsynthSetup.h
+++ b/src/qsynthSetup.h
@@ -69,6 +69,7 @@ public:
 	int     iAudioBufCount;
 	QString sSampleFormat;
 	float   fSampleRate;
+    bool    bWasapiExclusive;
 	int     iPolyphony;
 	bool    bReverbActive;
 	double  fReverbRoom;

--- a/src/qsynthSetupForm.cpp
+++ b/src/qsynthSetupForm.cpp
@@ -326,6 +326,9 @@ qsynthSetupForm::qsynthSetupForm ( QWidget *pParent )
 	QObject::connect(m_ui.JackNameComboBox,
 		SIGNAL(editTextChanged(const QString&)),
 		SLOT(settingsChanged()));
+    QObject::connect(m_ui.WasapiExclusiveCheckBox,
+        SIGNAL(stateChanged(int)),
+        SLOT(settingsChanged()));
 	QObject::connect(m_ui.SoundFontListView,
 		SIGNAL(customContextMenuRequested(const QPoint&)),
 		SLOT(contextMenuRequested(const QPoint&)));
@@ -497,6 +500,7 @@ void qsynthSetupForm::setup ( qsynthOptions *pOptions, qsynthEngine *pEngine, bo
 	m_ui.PolyphonySpinBox->setValue(m_pSetup->iPolyphony);
 	m_ui.JackMultiCheckBox->setChecked(m_pSetup->bJackMulti);
 	m_ui.JackAutoConnectCheckBox->setChecked(m_pSetup->bJackAutoConnect);
+    m_ui.WasapiExclusiveCheckBox->setChecked(m_pSetup->bWasapiExclusive);
 	// JACK client name...
 	QString sJackName;
 	if (!m_pSetup->sDisplayName.contains(QSYNTH_TITLE))
@@ -604,6 +608,7 @@ void qsynthSetupForm::accept (void)
 		m_pSetup->bJackMulti       = m_ui.JackMultiCheckBox->isChecked();
 		m_pSetup->sJackName        = m_ui.JackNameComboBox->currentText();
 		m_pSetup->bJackAutoConnect = m_ui.JackAutoConnectCheckBox->isChecked();
+        m_pSetup->bWasapiExclusive = m_ui.WasapiExclusiveCheckBox->isChecked();
 		// Reset dirty flag.
 		m_iDirtyCount = 0;
 	}
@@ -767,12 +772,14 @@ void qsynthSetupForm::stabilizeForm (void)
 #endif
 	const bool bJackEnabled = (m_ui.AudioDriverComboBox->currentText() == "jack");
 	const bool bJackMultiEnabled = m_ui.JackMultiCheckBox->isChecked();
-	m_ui.AudioDeviceTextLabel->setEnabled(!bJackEnabled);
+    const bool bWasapiEnabled = (m_ui.AudioDriverComboBox->currentText() == "wasapi");
+    m_ui.AudioDeviceTextLabel->setEnabled(!bJackEnabled);
 	m_ui.AudioDeviceComboBox->setEnabled(!bJackEnabled);
 	m_ui.JackMultiCheckBox->setEnabled(bJackEnabled);
 	m_ui.JackAutoConnectCheckBox->setEnabled(bJackEnabled);
 	m_ui.JackNameTextLabel->setEnabled(bJackEnabled);
 	m_ui.JackNameComboBox->setEnabled(bJackEnabled);
+    m_ui.WasapiExclusiveCheckBox->setEnabled(bWasapiEnabled);
 	if (bJackEnabled) {
 		m_ui.AudioChannelsTextLabel->setEnabled(bJackMultiEnabled);
 		m_ui.AudioChannelsSpinBox->setEnabled(bJackMultiEnabled);

--- a/src/qsynthSetupForm.ui
+++ b/src/qsynthSetupForm.ui
@@ -853,6 +853,13 @@
          </property>
         </spacer>
        </item>
+       <item row="6" column="0">
+        <widget class="QCheckBox" name="WasapiExclusiveCheckBox">
+         <property name="text">
+          <string>WASAPI Exclusive Mode</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="SoundFontTabPage">
@@ -1122,6 +1129,7 @@
   <tabstop>JackNameComboBox</tabstop>
   <tabstop>JackAutoConnectCheckBox</tabstop>
   <tabstop>JackMultiCheckBox</tabstop>
+  <tabstop>WasapiExclusiveCheckBox</tabstop>
   <tabstop>SoundFontListView</tabstop>
   <tabstop>SoundFontOpenPushButton</tabstop>
   <tabstop>SoundFontEditPushButton</tabstop>


### PR DESCRIPTION
This option allows to control the Fluidsynth's WASAPI driver exclusive mode from Qsynth.

Note: this would be the last problem for integrating a future Fluidsynth release > 2.2.0 for Windows, because the other COM initialization problem has been fixed in Fluidsynth git HEAD.
