### PR TITLE
Fix for ticket #54: Non existing signals when compiling with Qt6

### DIFF
--- a/src/qsynthSetupForm.cpp
+++ b/src/qsynthSetupForm.cpp
@@ -267,8 +267,8 @@ qsynthSetupForm::qsynthSetupForm ( QWidget *pParent )
 		SIGNAL(stateChanged(int)),
 		SLOT(settingsChanged()));
 	QObject::connect(m_ui.MidiDriverComboBox,
-		SIGNAL(activated(const QString&)),
-		SLOT(midiDriverChanged(const QString&)));
+		SIGNAL(activated(int)),
+		SLOT(midiDriverChanged(int)));
 	QObject::connect(m_ui.MidiDeviceComboBox,
 		SIGNAL(editTextChanged(const QString&)),
 		SLOT(settingsChanged()));
@@ -288,11 +288,11 @@ qsynthSetupForm::qsynthSetupForm ( QWidget *pParent )
 		SIGNAL(editTextChanged(const QString&)),
 		SLOT(settingsChanged()));
 	QObject::connect(m_ui.MidiBankSelectComboBox,
-		SIGNAL(activated(const QString&)),
+		SIGNAL(activated(int)),
 		SLOT(settingsChanged()));
 	QObject::connect(m_ui.AudioDriverComboBox,
-		SIGNAL(activated(const QString&)),
-		SLOT(audioDriverChanged(const QString&)));
+		SIGNAL(activated(int)),
+		SLOT(audioDriverChanged(int)));
 	QObject::connect(m_ui.AudioDeviceComboBox,
 		SIGNAL(editTextChanged(const QString&)),
 		SLOT(settingsChanged()));
@@ -698,11 +698,12 @@ void qsynthSetupForm::updateMidiDevices ( const QString& sMidiDriver )
 }
 
 
-void qsynthSetupForm::midiDriverChanged ( const QString& sMidiDriver )
+void qsynthSetupForm::midiDriverChanged ( int )
 {
 	if (m_iDirtySetup > 0)
 		return;
 
+	QString sMidiDriver = m_ui.MidiDriverComboBox->currentText();
 	QString sMidiDevice = m_ui.MidiDeviceComboBox->currentText();
 	updateMidiDevices(sMidiDriver);
 	setComboBoxCurrentText(m_ui.MidiDeviceComboBox, sMidiDevice);
@@ -730,11 +731,12 @@ void qsynthSetupForm::updateAudioDevices ( const QString& sAudioDriver )
 	m_ui.AudioDeviceComboBox->addItems(data.options);
 }
 
-void qsynthSetupForm::audioDriverChanged ( const QString& sAudioDriver )
+void qsynthSetupForm::audioDriverChanged ( int )
 {
 	if (m_iDirtySetup > 0)
 		return;
 
+	const QString& sAudioDriver = m_ui.AudioDriverComboBox->currentText();
 	const QString& sAudioDevice = m_ui.AudioDeviceComboBox->currentText();
 	updateAudioDevices(sAudioDriver);
 	setComboBoxCurrentText(m_ui.AudioDeviceComboBox, sAudioDevice);

--- a/src/qsynthSetupForm.h
+++ b/src/qsynthSetupForm.h
@@ -51,8 +51,8 @@ public:
 public slots:
 
 	void nameChanged(const QString&);
-	void midiDriverChanged(const QString&);
-	void audioDriverChanged(const QString&);
+	void midiDriverChanged(int index);
+	void audioDriverChanged(int index);
 	void settingsChanged();
 
 	void contextMenuRequested(const QPoint&);


### PR DESCRIPTION
When builing Qsynth with Qt6, the following messages are logged at runtime:

qt.core.qobject.connect: QObject::connect: No such signal QComboBox::activated(const QString&)
qt.core.qobject.connect: QObject::connect: (sender name: 'MidiDriverComboBox')
qt.core.qobject.connect: QObject::connect: (receiver name: 'qsynthSetupForm')
qt.core.qobject.connect: QObject::connect: No such signal QComboBox::activated(const QString&)
qt.core.qobject.connect: QObject::connect: (sender name: 'MidiBankSelectComboBox')
qt.core.qobject.connect: QObject::connect: (receiver name: 'qsynthSetupForm')
qt.core.qobject.connect: QObject::connect: No such signal QComboBox::activated(const QString&)
qt.core.qobject.connect: QObject::connect: (sender name: 'AudioDriverComboBox')
qt.core.qobject.connect: QObject::connect: (receiver name: 'qsynthSetupForm')

The signal QComboBox::activated(QString&) has been removed from Qt6, and now only the QComboBox::activated(int) is available.

References:
https://doc.qt.io/qt-5/qcombobox-obsolete.html#activated-1
https://doc.qt.io/qt-6/qcombobox.html#activated