### PR TITLE
Fixes for qsynth/develop branch

### DIFF
--- a/src/qsynth.cpp
+++ b/src/qsynth.cpp
@@ -55,7 +55,7 @@ const WindowFlags WindowCloseButtonHint = WindowFlags(0x08000000);
 #endif
 
 #ifndef CONFIG_LIBDIR
-#if defined(__x86_64__)
+#if defined(Q_PROCESSOR_X86_64)
 #define CONFIG_LIBDIR  CONFIG_PREFIX "/lib64"
 #else
 #define CONFIG_LIBDIR  CONFIG_PREFIX "/lib"
@@ -447,7 +447,7 @@ void qsynthApplication::readyReadSlot (void)
 //
 
 #ifdef CONFIG_STACKTRACE
-#if defined(__GNUC__) && defined(Q_OS_LINUX)
+#if defined(Q_CC_GNU) && defined(Q_OS_LINUX)
 
 #include <stdio.h>
 #include <errno.h>
@@ -508,7 +508,7 @@ int main ( int argc, char **argv )
 {
 	Q_INIT_RESOURCE(qsynth);
 #ifdef CONFIG_STACKTRACE
-#if defined(__GNUC__) && defined(Q_OS_LINUX)
+#if defined(Q_CC_GNU) && defined(Q_OS_LINUX)
 	::signal(SIGILL,  stacktrace);
 	::signal(SIGFPE,  stacktrace);
 	::signal(SIGSEGV, stacktrace);

--- a/src/qsynth.cpp
+++ b/src/qsynth.cpp
@@ -165,10 +165,8 @@ void qsynthApplication::loadTranslations(const QString& sLanguage)
 	}
 
 	QString sLocPath = qsynthApplication::prefixPath;
-#if defined(Q_OS_WINDOWS)
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_MACOS)
 	sLocPath.append("/translations");
-#elif defined(Q_OS_MACOS)
-	sLocPath.append("/Resources");
 #else
 	sLocPath.append(CONFIG_DATADIR "/qsynth/translations");
 #endif

--- a/src/qsynthMainForm.cpp
+++ b/src/qsynthMainForm.cpp
@@ -1,7 +1,7 @@
 // qsynthMainForm.cpp
 //
 /****************************************************************************
-   Copyright (C) 2003-2021, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2003-2022, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -85,7 +85,7 @@ const WindowFlags WindowCloseButtonHint = WindowFlags(0x08000000);
 #define QSYNTH_CHORUS_SPEED_SCALE   100.0f
 #define QSYNTH_CHORUS_DEPTH_SCALE   10.0f
 
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 #undef HAVE_SIGNAL_H
 #else
 #include <unistd.h>
@@ -790,7 +790,7 @@ void qsynthMainForm::setup ( qsynthOptions *pOptions )
 	// Knobs
 	updateKnobs();
 
-#if !defined(__WIN32__) && !defined(_WIN32) && !defined(WIN32)
+#if !defined(Q_OS_WINDOWS)
 	// Check if we can redirect our own stdout/stderr...
 	if (m_pOptions->bStdoutCapture && ::pipe(g_fdStdout) == 0) {
 		::dup2(g_fdStdout[QSYNTH_FDWRITE], STDOUT_FILENO);
@@ -1131,7 +1131,7 @@ void qsynthMainForm::sigtermNotifySlot ( int /* fd */ )
 // Set stdout/stderr blocking mode.
 bool qsynthMainForm::stdoutBlock ( int fd, bool bBlock ) const
 {
-#if !defined(__WIN32__) && !defined(_WIN32) && !defined(WIN32)
+#if !defined(Q_OS_WINDOWS)
 	const int iFlags = ::fcntl(fd, F_GETFL, 0);
 	const bool bNonBlock = bool(iFlags & O_NONBLOCK);
 	if (bBlock && bNonBlock)
@@ -1147,7 +1147,7 @@ bool qsynthMainForm::stdoutBlock ( int fd, bool bBlock ) const
 // Own stdout/stderr socket notifier slot.
 void qsynthMainForm::stdoutNotifySlot ( int fd )
 {
- #if !defined(__WIN32__) && !defined(_WIN32) && !defined(WIN32)
+ #if !defined(Q_OS_WINDOWS)
 	// Set non-blocking reads, if not already...
 	const bool bBlock = stdoutBlock(fd, false);
 	// Read as much as is available...
@@ -1187,7 +1187,7 @@ void qsynthMainForm::processStdoutBuffer (void)
 		while (iter.hasNext()) {
 			const QString& sTemp = iter.next();
 			if (!sTemp.isEmpty())
-			#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+			#if defined(Q_OS_WINDOWS)
 				appendMessagesText(sTemp.trimmed());
 			#else
 				appendMessagesText(sTemp);
@@ -1204,7 +1204,7 @@ void qsynthMainForm::flushStdoutBuffer (void)
 	processStdoutBuffer();
 
 	if (!m_sStdoutBuffer.isEmpty()) {
-	#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+	#if defined(Q_OS_WINDOWS)
 		appendMessagesText(m_sStdoutBuffer.trimmed());
 	#else
 		appendMessagesText(m_sStdoutBuffer);

--- a/src/qsynthOptions.cpp
+++ b/src/qsynthOptions.cpp
@@ -1,7 +1,7 @@
 // qsynthOptions.cpp
 //
 /****************************************************************************
-   Copyright (C) 2003-2021, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2003-2022, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -516,20 +516,20 @@ void qsynthOptions::loadSetup ( qsynthSetup *pSetup, const QString& sName )
 	m_settings.beginGroup("/Settings");
 	pSetup->sDisplayName     = m_settings.value("/DisplayName", sDisplayName).toString();
 	pSetup->bMidiIn          = m_settings.value("/MidiIn", true).toBool();
-#if defined(__APPLE__)
+#if defined(Q_OS_MACOS)
 	pSetup->sMidiDriver      = m_settings.value("/MidiDriver", "coremidi").toString();
 	pSetup->sAudioDriver     = m_settings.value("/AudioDriver", "coreaudio").toString();
-#elif defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#elif defined(Q_OS_WINDOWS)
 	pSetup->sMidiDriver      = m_settings.value("/MidiDriver", "winmidi").toString();
 	pSetup->sAudioDriver     = m_settings.value("/AudioDriver", "dsound").toString();
-#elif defined(__OpenBSD__)
+#elif defined(Q_OS_OPENBSD)
 	pSetup->sMidiDriver      = m_settings.value("/MidiDriver", "sndio").toString();
 	pSetup->sAudioDriver     = m_settings.value("/AudioDriver", "sndio").toString();
 #else
 	pSetup->sMidiDriver      = m_settings.value("/MidiDriver", "alsa_seq").toString();
 	pSetup->sAudioDriver     = m_settings.value("/AudioDriver", "jack").toString();
 #endif
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 	pSetup->iAudioBufSize    = m_settings.value("/AudioBufSize", 512).toInt();
 	pSetup->iAudioBufCount   = m_settings.value("/AudioBufCount", 8).toInt();
 #else
@@ -542,7 +542,7 @@ void qsynthOptions::loadSetup ( qsynthSetup *pSetup, const QString& sName )
 	pSetup->bJackAutoConnect = m_settings.value("/JackAutoConnect", true).toBool();
 	pSetup->bJackMulti       = m_settings.value("/JackMulti", false).toBool();
 	pSetup->bWasapiExclusive = m_settings.value("/WasapiExclusive", false).toBool();
-#if defined(__OpenBSD__)
+#if defined(Q_OS_OPENBSD)
 	pSetup->sMidiDevice      = m_settings.value("/MidiDevice", "midithru/0").toString();
 #else
 	pSetup->sMidiDevice      = m_settings.value("/MidiDevice").toString();

--- a/src/qsynthOptions.h
+++ b/src/qsynthOptions.h
@@ -1,7 +1,7 @@
 // qsynthOptions.h
 //
 /****************************************************************************
-   Copyright (C) 2003-2021, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2003-2022, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License

--- a/src/qsynthOptionsForm.cpp
+++ b/src/qsynthOptionsForm.cpp
@@ -1,7 +1,7 @@
 // qsynthOptionsForm.cpp
 //
 /****************************************************************************
-   Copyright (C) 2003-2020, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2003-2022, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -203,7 +203,7 @@ void qsynthOptionsForm::setup ( qsynthOptions *pOptions )
 	m_ui.KnobStyleComboBox->setCurrentIndex(m_pOptions->iKnobStyle);
 	m_ui.KnobMouseMotionComboBox->setCurrentIndex(m_pOptions->iKnobMotion);
 
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 	m_ui.StdoutCaptureCheckBox->setChecked(false);
 	m_ui.StdoutCaptureCheckBox->setEnabled(false);
 #endif

--- a/src/qsynthOptionsForm.h
+++ b/src/qsynthOptionsForm.h
@@ -1,7 +1,7 @@
 // qsynthOptionsForm.h
 //
 /****************************************************************************
-   Copyright (C) 2003-2020, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2003-2022, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License

--- a/src/qsynthSetup.cpp
+++ b/src/qsynthSetup.cpp
@@ -1,7 +1,7 @@
 // qsynthSetup.cpp
 //
 /****************************************************************************
-   Copyright (C) 2003-2021, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2003-2022, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -144,7 +144,7 @@ void qsynthSetup::realize (void)
 #endif
 
 #if (FLUIDSYNTH_VERSION_MAJOR >= 2 && FLUIDSYNTH_VERSION_MINOR >= 2) || (FLUIDSYNTH_VERSION_MAJOR > 2)
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 	pszKey = (char *) "audio.wasapi.exclusive-mode";
 	::fluid_settings_setint(m_pFluidSettings, pszKey,
 		int(bWasapiExclusive));

--- a/src/qsynthSetupForm.cpp
+++ b/src/qsynthSetupForm.cpp
@@ -326,7 +326,7 @@ qsynthSetupForm::qsynthSetupForm ( QWidget *pParent )
 	QObject::connect(m_ui.JackNameComboBox,
 		SIGNAL(editTextChanged(const QString&)),
 		SLOT(settingsChanged()));
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 	QObject::connect(m_ui.WasapiExclusiveCheckBox,
 		SIGNAL(stateChanged(int)),
 		SLOT(settingsChanged()));
@@ -502,7 +502,7 @@ void qsynthSetupForm::setup ( qsynthOptions *pOptions, qsynthEngine *pEngine, bo
 	m_ui.PolyphonySpinBox->setValue(m_pSetup->iPolyphony);
 	m_ui.JackMultiCheckBox->setChecked(m_pSetup->bJackMulti);
 	m_ui.JackAutoConnectCheckBox->setChecked(m_pSetup->bJackAutoConnect);
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 	m_ui.WasapiExclusiveCheckBox->setChecked(m_pSetup->bWasapiExclusive);
 #else
 	m_ui.WasapiExclusiveCheckBox->hide();
@@ -614,7 +614,7 @@ void qsynthSetupForm::accept (void)
 		m_pSetup->bJackMulti       = m_ui.JackMultiCheckBox->isChecked();
 		m_pSetup->sJackName        = m_ui.JackNameComboBox->currentText();
 		m_pSetup->bJackAutoConnect = m_ui.JackAutoConnectCheckBox->isChecked();
-	#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+	#if defined(Q_OS_WINDOWS)
 		m_pSetup->bWasapiExclusive = m_ui.WasapiExclusiveCheckBox->isChecked();
 	#endif
 		// Reset dirty flag.
@@ -782,7 +782,7 @@ void qsynthSetupForm::stabilizeForm (void)
 #endif
 	const bool bJackEnabled = (m_ui.AudioDriverComboBox->currentText() == "jack");
 	const bool bJackMultiEnabled = m_ui.JackMultiCheckBox->isChecked();
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 	const bool bWasapiEnabled = (m_ui.AudioDriverComboBox->currentText() == "wasapi");
 #endif
 	m_ui.AudioDeviceTextLabel->setEnabled(!bJackEnabled);
@@ -791,7 +791,7 @@ void qsynthSetupForm::stabilizeForm (void)
 	m_ui.JackAutoConnectCheckBox->setEnabled(bJackEnabled);
 	m_ui.JackNameTextLabel->setEnabled(bJackEnabled);
 	m_ui.JackNameComboBox->setEnabled(bJackEnabled);
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+#if defined(Q_OS_WINDOWS)
 	m_ui.WasapiExclusiveCheckBox->setEnabled(bWasapiEnabled);
 #endif
 	if (bJackEnabled) {


### PR DESCRIPTION
* Fixed error on #57: the location of translation files on mac was wrong
* Conditional compilation macros replaced
* Updated copyright years of the modified sources