### PR TITLE
Add pw_init() to support PipeWire

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ else ()
   set (CONFIG_FLUIDSYNTH 0)
 endif ()
 
+pkg_check_modules (PIPEWIRE IMPORTED_TARGET libpipewire-0.3)
+set (CONFIG_PIPEWIRE ${PIPEWIRE_FOUND})
 
 add_subdirectory (src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,10 @@ if (CONFIG_ROUND)
   target_link_libraries (${PROJECT_NAME} PRIVATE ${MATH_LIBRARY})
 endif ()
 
+if (CONFIG_PIPEWIRE)
+  target_link_libraries (${PROJECT_NAME} PRIVATE PkgConfig::PIPEWIRE)
+endif ()
+
 
 if (UNIX AND NOT APPLE)
   install (TARGETS ${PROJECT_NAME} RUNTIME

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -130,4 +130,7 @@
 /* Define if Wayland is supported */
 #cmakedefine CONFIG_WAYLAND @CONFIG_WAYLAND@
 
+/* Define if PipeWire is available */
+#cmakedefine CONFIG_PIPEWIRE @CONFIG_PIPEWIRE@
+
 #endif /* CONFIG_H */

--- a/src/qsynth.cpp
+++ b/src/qsynth.cpp
@@ -36,6 +36,10 @@
 
 #include <QSessionManager>
 
+#if CONFIG_PIPEWIRE
+#include <pipewire/pipewire.h>
+#endif
+
 #if QT_VERSION < QT_VERSION_CHECK(4, 5, 0)
 namespace Qt {
 const WindowFlags WindowCloseButtonHint = WindowFlags(0x08000000);
@@ -572,6 +576,12 @@ void stacktrace ( int signo )
 
 int main ( int argc, char **argv )
 {
+#if CONFIG_PIPEWIRE
+	// Initialize PipeWire first
+	::pw_init(&argc, &argv);
+	::atexit(::pw_deinit);
+#endif
+
 	Q_INIT_RESOURCE(qsynth);
 #ifdef CONFIG_STACKTRACE
 #if defined(Q_CC_GNU) && defined(Q_OS_LINUX)


### PR DESCRIPTION
Fluidsynth added support for PipeWire, but Qsynth can't use that (it doesn't call pw_init()).
This patch adds PipeWire support.