### PR TITLE
fix win32 setup.nsi.in uninstallation

### DIFF
--- a/src/translations/qsynth_zh_CN.ts
+++ b/src/translations/qsynth_zh_CN.ts
@@ -1266,12 +1266,12 @@ next time you start this application.</source>
     <message>
         <location filename="../qsynthOptionsForm.ui" line="513"/>
         <source>Vokimon</source>
-        <translation>沃奇蒙</translation>
+        <translation>Vokimon</translation>
     </message>
     <message>
         <location filename="../qsynthOptionsForm.ui" line="518"/>
         <source>Peppino</source>
-        <translation>佩皮诺</translation>
+        <translation>Peppino</translation>
     </message>
     <message>
         <location filename="../qsynthOptionsForm.ui" line="528"/>
@@ -1422,7 +1422,7 @@ next time you start this application.</source>
     <message>
         <location filename="../qsynthOptionsForm.ui" line="523"/>
         <source>Skulpture</source>
-        <translation>雕塑</translation>
+        <translation>Skulpture</translation>
     </message>
 </context>
 <context>

--- a/src/win32/setup.nsi.in
+++ b/src/win32/setup.nsi.in
@@ -255,7 +255,7 @@ Section /o -un.Main UNSEC0000
 #    !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\imageformats\qwebp.dll
     !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\networkinformation\qnetworklistmanager.dll
     !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\platforms\qwindows.dll
-    !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\styles\qwindowsvistastyle.dll
+    !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\styles\qmodernwindowsstyle.dll
     !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\tls\qcertonlybackend.dll
     !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\tls\qopensslbackend.dll
     !insertmacro UnInstallLib DLL NOTSHARED REBOOT_PROTECTED $INSTDIR\tls\qschannelbackend.dll


### PR DESCRIPTION
qmodernwindowsstyle.dll is miswritten as qwindowsvistastyle.dll, which results in file remaining during uninstallation.